### PR TITLE
show warning when legacy argument passed to verify functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ install:
   - conda config --set auto_update_conda False
   - conda update -q --all
   - conda install pytest pytest-cov pytest-mock pyyaml click jinja2
+  - conda install -c conda-forge pytest-catchlog
   - if [[ "$CONDA_BUILD" == "1" ]]; then
       conda install -q conda-build && conda remove -q conda-build && git clone https://github.com/conda/conda-build && pushd conda-build && pip install -e . && popd && conda remove -q conda-verify;
     fi

--- a/conda_verify/verify.py
+++ b/conda_verify/verify.py
@@ -5,15 +5,23 @@ import sys
 from conda_verify.checks import CondaPackageCheck, CondaRecipeCheck
 from conda_verify.errors import PackageError, RecipeError
 from conda_verify.utilities import ensure_list
+from logging import getLogger
 
 
 class Verify(object):
     """Verify class is called by the CLI but may be used as an API as well."""
 
     @staticmethod
-    def verify_package(path_to_package=None, checks_to_ignore=None, exit_on_error=False):
+    def verify_package(path_to_package=None, checks_to_ignore=None, exit_on_error=False,
+                       **kw):
         """Run all package checks in order to verify a conda package."""
         package_check = CondaPackageCheck(path_to_package)
+
+        if (('ignore_scripts' in kw and kw['ignore_scripts']) or
+                ('run_scripts' in kw and kw['run_scripts'])):
+            getLogger(__name__).warn('Ignoring legacy ignore_scripts or run_scripts.  These have '
+                    'been replaced by the checks_to_ignore argument, which takes a'
+                    'list of codes, documented at https://github.com/conda/conda-verify#checks')
 
         # collect all CondaPackageCheck methods that start with the word 'check'
         # this should later be a decorator that is placed on each check
@@ -41,9 +49,17 @@ class Verify(object):
 
     @staticmethod
     def verify_recipe(rendered_meta=None, recipe_dir=None, checks_to_ignore=None,
-                      exit_on_error=False):
-        """Run all recipe checks in order to verify a conda recipe."""
+                      exit_on_error=False, **kw):
+        """Run all recipe checks in order to verify a conda recipe.
+        checks_to_ignore should be a list, tuple, or set of codes, such as ['C2102', 'C2104'].
+        Codes are listed in readme.md"""
         recipe_check = CondaRecipeCheck(rendered_meta, recipe_dir)
+
+        if (('ignore_scripts' in kw and kw['ignore_scripts']) or
+                ('run_scripts' in kw and kw['run_scripts'])):
+            getLogger(__name__).warn('Ignoring legacy ignore_scripts or run_scripts.  These have '
+                    'been replaced by the checks_to_ignore argument, which takes a'
+                    'list of codes, documented at https://github.com/conda/conda-verify#checks')
 
         # collect all CondaRecipeCheck methods that start with the word 'check'
         # this should later be a decorator that is placed on each check

--- a/tests/functional_tests/test_valid_packages.py
+++ b/tests/functional_tests/test_valid_packages.py
@@ -77,3 +77,15 @@ def test_valid_preferred_env(package_dir, verifier):
         verifier.verify_package(path_to_package=package)
     except SystemExit as error:
         pytest.fail(error)
+
+
+def test_passing_legacy_arguments_to_package_shows_warning(package_dir, verifier, caplog):
+    package = os.path.join(package_dir, 'testfile-0.0.37-py36_0.tar.bz2')
+
+    verifier.verify_package(path_to_package=package, run_scripts=None, ignore_scripts=None)
+    assert caplog.text.count('Ignoring legacy ignore_scripts or run_scripts.') == 0
+    verifier.verify_package(path_to_package=package, run_scripts='abc.py')
+    assert caplog.text.count('Ignoring legacy ignore_scripts or run_scripts.') == 1
+    verifier.verify_package(path_to_package=package, ignore_scripts='abc.py')
+    # actually only one more, but we still have the earlier one in the pipe, too.
+    assert caplog.text.count('Ignoring legacy ignore_scripts or run_scripts.') == 2

--- a/tests/functional_tests/test_valid_recipes.py
+++ b/tests/functional_tests/test_valid_recipes.py
@@ -25,3 +25,17 @@ def test_valid_test_file(recipe_dir, verifier):
         verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe)
     except SystemExit as error:
         pytest.fail(error)
+
+
+def test_passing_legacy_arguments_to_recipe_shows_warning(recipe_dir, verifier, caplog):
+    recipe = os.path.join(recipe_dir, 'valid_test_file')
+    metadata = utilities.render_metadata(recipe, None)
+
+    verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe, run_scripts=None,
+                           ignore_scripts=None)
+    assert caplog.text.count('Ignoring legacy ignore_scripts or run_scripts.') == 0
+    verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe, run_scripts='abc.py')
+    assert caplog.text.count('Ignoring legacy ignore_scripts or run_scripts.') == 1
+    verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe, ignore_scripts='abc.py')
+    # actually only one more, but we still have the earlier one in the pipe, too.
+    assert caplog.text.count('Ignoring legacy ignore_scripts or run_scripts.') == 2


### PR DESCRIPTION
CC @mandeep - I think this will keep old conda-build versions working.  It's not terribly important to translate the old functionality into new functionality, since none of the old packages actually worked.  There's not much chance anyone will miss the old functionality.