### PR TITLE
Make sure data is a byte array

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
   - conda config --set always_yes yes
   - conda config --set auto_update_conda False
   - conda update -q --all
-  - conda install pytest pytest-cov pytest-mock pyyaml click jinja2
+  - conda install pytest pytest-cov pytest-mock pyyaml click future jinja2
   - conda install -c conda-forge pytest-catchlog
   - if [[ "$CONDA_BUILD" == "1" ]]; then
       conda install -q conda-build && conda remove -q conda-build && git clone https://github.com/conda/conda-build && pushd conda-build && pip install -e . && popd && conda remove -q conda-verify;

--- a/conda_verify/utilities.py
+++ b/conda_verify/utilities.py
@@ -4,6 +4,8 @@ import sys
 import jinja2
 import yaml
 
+import future.builtins
+
 from conda_verify.constants import MAGIC_HEADERS, DLL_TYPES
 
 try:
@@ -113,6 +115,7 @@ def get_object_type(data):
         pos = data.find(b'PE\0\0')
         if pos < 0:
             return "<no PE header found>"
+        data = future.builtins.bytes(data)
         i = data[pos + 4] + 256 * data[pos + 5]
         return "DLL " + DLL_TYPES.get(i)
     elif lookup.startswith('MachO'):

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,7 @@ requirements:
     - jinja2
     - click
     - pyyaml
+    - future
     - backports.functools_lru_cache  # [py<33]
 
 build:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 from conda_verify import __version__
 
 
-requirements = ['click >= 6.7', 'jinja2 >= 2.9', 'pyyaml >= 3.12']
+requirements = ['click >= 6.7', 'future >= 0.12.0', 'jinja2 >= 2.9', 'pyyaml >= 3.12']
 if sys.version_info.major == 2:
     requirements.append('backports.functools_lru_cache >= 1.4')
 


### PR DESCRIPTION
Py3 interprets `data` as 'bytes' and Py2 as 'str', because of which it throws
the traceback:
```
  File "build/bdist.linux-x86_64/egg/conda_verify/cli.py", line 40, in cli
  File "build/bdist.linux-x86_64/egg/conda_verify/verify.py", line 30, in verify_package
  File "build/bdist.linux-x86_64/egg/conda_verify/checks.py", line 310, in check_windows_arch
  File "build/bdist.linux-x86_64/egg/conda_verify/utilities.py", line 120, in get_object_type
TypeError: cannot concatenate 'str' and 'NoneType' objects
```
This patch makes sure that the input for computing the DLL_TYPE is indeed an
integer, by changing data to a byte array.