### PR TITLE
Fix C1129 being thrown when filename is enclosed in quotes

### DIFF
--- a/conda_verify/checks.py
+++ b/conda_verify/checks.py
@@ -218,6 +218,8 @@ class CondaPackageCheck(object):
                     line = line.strip()
                     try:
                         placeholder, mode, filename = line.split()
+                        placeholder = placeholder.strip("'\"")
+                        filename = filename.strip("'\"")
                     except ValueError:
                         placeholder, mode, filename = '/<dummy>/<placeholder>', 'text', line
 


### PR DESCRIPTION
fixes #30 