### PR TITLE
Add versioneer.py and _version.py to omissions

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,3 +4,5 @@ omit =
     setup.py
     tests/*
     *__main__.py
+    versioneer.py
+    *_version.py


### PR DESCRIPTION
This adds versioneer.py and _version.py to the coveragerc omissions so that the two files aren't reported in coverage.