### PR TITLE
make exiting optional; print all errors always

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ install:
   - conda config --set auto_update_conda False
   - conda update -q --all
   - conda install pytest pytest-cov pytest-mock pyyaml click future jinja2
-  - conda install -c conda-forge pytest-catchlog
   - if [[ "$CONDA_BUILD" == "1" ]]; then
       conda install -q conda-build && conda remove -q conda-build && git clone https://github.com/conda/conda-build && pushd conda-build && pip install -e . && popd && conda remove -q conda-verify;
     fi

--- a/conda_verify/checks.py
+++ b/conda_verify/checks.py
@@ -23,6 +23,7 @@ from conda_verify.utilities import (all_ascii, get_bad_seq, get_object_type,
 
 ver_spec_pat = '^(?:[><=]{0,2}(?:(?:[\d\*]+[!\._]?){1,})[+\w\*]*[|,]?){1,}'
 
+
 class CondaPackageCheck(object):
     """Create checks in order to validate conda package tarballs."""
 
@@ -427,8 +428,9 @@ class CondaRecipeCheck(object):
 
     def check_fields(self):
         """Check that the fields listed in meta.yaml are valid."""
+
         for section in self.meta:
-            if section not in FIELDS:
+            if section not in FIELDS and section != 'extra':
                 return Error(self.recipe_dir, 'C2109', u'Found invalid section "{}"' .format(section))
 
             if section != 'extra':

--- a/conda_verify/cli.py
+++ b/conda_verify/cli.py
@@ -32,7 +32,7 @@ def cli(path, ignore, exit):
             meta = render_metadata(path, cfg)
             if meta.get('build', {}).get('skip', '').lower() != 'true':
                 verifier.verify_recipe(rendered_meta=meta, recipe_dir=path,
-                                    checks_to_ignore=ignore, exit_on_error=exit)
+                                       checks_to_ignore=ignore, exit_on_error=exit)
 
     elif path.endswith(('.tar.bz2', '.tar')):
         print('Verifying {}...' .format(path))

--- a/conda_verify/constants.py
+++ b/conda_verify/constants.py
@@ -1,29 +1,39 @@
-LICENSE_FAMILIES = ['AGPL', 'GPL2', 'GPL3', 'LGPL', 'BSD', 'MIT', 'Apache',
-                    'PSF', 'Public-Domain', 'Proprietary', 'Other']
+try:
+    from conda_build.license_family import allowed_license_families as LICENSE_FAMILIES
+except ImportError:
+    print("warning: could not import conda-build ALLOWED_LICENSE_FAMILIES data.  Falling back to "
+          "possibly stale static list")
+    LICENSE_FAMILIES = ['AGPL', 'GPL2', 'GPL3', 'LGPL', 'BSD', 'MIT', 'Apache',
+                        'PSF', 'Public-Domain', 'Proprietary', 'Other']
 
-FIELDS = {
-    'package': {'name', 'version'},
-    'source': {'fn', 'url', 'md5', 'sha1', 'sha256',
-               'git_url', 'git_tag', 'git_branch', 'git_rev',
-               'patches', 'hg_url', 'hg_tag', 'path'},
-    'build': {'features', 'track_features', 'skip',
-              'number', 'entry_points', 'osx_is_app', 'noarch',
-              'preserve_egg_dir', 'win_has_prefix', 'no_link',
-              'ignore_prefix_files', 'msvc_compiler', 'skip_compile_pyc',
-              'detect_binary_files_with_prefix', 'script',
-              'always_include_files', 'binary_relocation',
-              'binary_has_prefix_files', 'noarch_python', 'run_exports'},
-    'requirements': {'build', 'run', 'preferred_env', 'host',
-                     'preferred_env_executable_paths'},
-    'outputs': {'name', 'build', 'about', 'test', 'version', 'script', 'requirements',
-                'run_exports'},
-    'app': {'entry', 'icon', 'summary', 'type', 'cli_opts'},
-    'test': {'requires', 'commands', 'files', 'source_files', 'imports'},
-    'about': {'license', 'license_url', 'license_family', 'license_file',
-              'summary', 'description', 'home', 'doc_url', 'doc_source_url',
-              'dev_url'},
-    'extra': {'recipe-maintainers', 'final', 'parent_recipe'},
-}
+try:
+    from conda_build.metadata import FIELDS
+except ImportError:
+    print("warning: could not import conda-build FIELDS data.  Falling back to possibly stale"
+          "static list")
+    FIELDS = {
+        'package': {'name', 'version'},
+        'source': {'fn', 'url', 'md5', 'sha1', 'sha256',
+                'git_url', 'git_tag', 'git_branch', 'git_rev',
+                'patches', 'hg_url', 'hg_tag', 'path'},
+        'build': {'features', 'track_features', 'skip',
+                'number', 'entry_points', 'osx_is_app', 'noarch',
+                'preserve_egg_dir', 'win_has_prefix', 'no_link',
+                'ignore_prefix_files', 'msvc_compiler', 'skip_compile_pyc',
+                'detect_binary_files_with_prefix', 'script',
+                'always_include_files', 'binary_relocation',
+                'binary_has_prefix_files', 'noarch_python', 'run_exports'},
+        'requirements': {'build', 'run', 'preferred_env', 'host',
+                        'preferred_env_executable_paths'},
+        'outputs': {'name', 'build', 'about', 'test', 'version', 'script', 'requirements',
+                    'run_exports'},
+        'app': {'entry', 'icon', 'summary', 'type', 'cli_opts'},
+        'test': {'requires', 'commands', 'files', 'source_files', 'imports'},
+        'about': {'license', 'license_url', 'license_family', 'license_file',
+                'summary', 'description', 'home', 'doc_url', 'doc_source_url',
+                'dev_url'},
+        'extra': {'recipe-maintainers', 'final', 'parent_recipe'},
+    }
 
 MAGIC_HEADERS = {
     b'\xca\xfe\xba\xbe': 'MachO-universal',

--- a/conda_verify/utilities.py
+++ b/conda_verify/utilities.py
@@ -3,6 +3,7 @@ import sys
 
 import jinja2
 import yaml
+from six import string_types
 
 import future.builtins
 
@@ -58,6 +59,8 @@ def ns_cfg(cfg):
 
 
 sel_pat = re.compile(r'(.+?)\s*\[(.+)\]$')
+
+
 def select_lines(data, namespace):
     lines = []
     for line in data.splitlines():
@@ -90,9 +93,11 @@ try:
     # circular dependency.  We only try this import so that conda-build is an optional
     #      conda-verify dep
     from conda_build import api
-    render_metadata = lambda recipe_dir, cfg: api.render(recipe_dir, finalize=False,
-                                                         bypass_env_check=True,
-                                                         **(cfg if cfg else {}))[0][0].meta
+
+    def render_metadata(recipe_dir, cfg):
+        m = api.render(recipe_dir, finalize=False, bypass_env_check=True,
+                       **(cfg if cfg else {}))[0][0]
+        return m.get_rendered_recipe_text()
 except ImportError:
     def render_metadata(recipe_dir, cfg):
         data = render_jinja2(recipe_dir)
@@ -147,6 +152,8 @@ def all_ascii(data, allow_CR=False):
 def ensure_list(argument):
     if isinstance(argument, list):
         return argument
+    elif isinstance(argument, string_types):
+        return argument.split(',')
     return [argument]
 
 

--- a/conda_verify/verify.py
+++ b/conda_verify/verify.py
@@ -14,7 +14,9 @@ class Verify(object):
     @staticmethod
     def verify_package(path_to_package=None, checks_to_ignore=None, exit_on_error=False,
                        **kw):
-        """Run all package checks in order to verify a conda package."""
+        """Run all package checks in order to verify a conda package.
+        checks_to_ignore should be a list, tuple, or set of codes, such as ['C1102', 'C1104'].
+        Codes are listed in readme.md.  Package codes follow 1xxx, recipe codes follow 2xxx."""
         package_check = CondaPackageCheck(path_to_package)
 
         if (('ignore_scripts' in kw and kw['ignore_scripts']) or
@@ -25,34 +27,30 @@ class Verify(object):
 
         # collect all CondaPackageCheck methods that start with the word 'check'
         # this should later be a decorator that is placed on each check
-        checks_to_display = [getattr(package_check, method)() for method
-                             in dir(package_check) if method.startswith('check') and
-                             getattr(package_check, method)() is not None]
+        checks_to_display = []
+        for method in dir(package_check):
+            if method.startswith('check'):
+                # runs the check
+                #  TODO: should have a way to skip checks if a check's codes are all ignored
+                check = getattr(package_check, method)()
+                if check is not None and check.code not in ensure_list(checks_to_ignore):
+                    checks_to_display.append(check)
 
-        return_code = 0
+        for check in sorted(checks_to_display):
+            try:
+                print(check, file=sys.stderr)
+            except UnicodeEncodeError:
+                print("Could not print message for error code {} due to unicode error".format(check.code), file=sys.stderr)
 
-        if len(checks_to_display) > 0:
-            for check in sorted(checks_to_display):
-                if check.code not in ensure_list(checks_to_ignore):
-                    check = u'{}' .format(check)
-                    if exit_on_error:
-                        raise PackageError(check)
-                    else:
-                        print(check, file=sys.stderr)
-
-                    return_code = 1
-
-        # by exiting at a return code greater than 0 we can assure failures
-        # in logs or continuous integration services
-        if return_code > 0:
-            sys.exit(return_code)
+        if checks_to_display and exit_on_error:
+            raise PackageError(check)
 
     @staticmethod
     def verify_recipe(rendered_meta=None, recipe_dir=None, checks_to_ignore=None,
                       exit_on_error=False, **kw):
         """Run all recipe checks in order to verify a conda recipe.
         checks_to_ignore should be a list, tuple, or set of codes, such as ['C2102', 'C2104'].
-        Codes are listed in readme.md"""
+        Codes are listed in readme.md.  Package codes follow 1xxx, recipe codes follow 2xxx."""
         recipe_check = CondaRecipeCheck(rendered_meta, recipe_dir)
 
         if (('ignore_scripts' in kw and kw['ignore_scripts']) or
@@ -61,25 +59,18 @@ class Verify(object):
                     'been replaced by the checks_to_ignore argument, which takes a'
                     'list of codes, documented at https://github.com/conda/conda-verify#checks')
 
-        # collect all CondaRecipeCheck methods that start with the word 'check'
-        # this should later be a decorator that is placed on each check
-        checks_to_display = [getattr(recipe_check, method)() for method
-                             in dir(recipe_check) if method.startswith('check') and
-                             getattr(recipe_check, method)() is not None]
+        checks_to_display = []
+        for method in dir(recipe_check):
+            if method.startswith('check'):
+                check = getattr(recipe_check, method)()
+                if check is not None and check.code not in ensure_list(checks_to_ignore):
+                    checks_to_display.append(check)
 
-        return_code = 0
+        for check in sorted(checks_to_display):
+            try:
+                print(check, file=sys.stderr)
+            except UnicodeEncodeError:
+                print(str(check).encode('utf-8', 'ignore'), file=sys.stderr)
 
-        if len(checks_to_display) > 0:
-            for check in sorted(checks_to_display):
-                if check.code not in ensure_list(checks_to_ignore):
-                    if exit_on_error:
-                        raise RecipeError(check)
-                    else:
-                        print(check, file=sys.stderr)
-
-                    return_code = 1
-
-        # by exiting at a return code greater than 0 we can assure failures
-        # in logs or continuous integration services
-        if return_code > 0:
-            sys.exit(return_code)
+        if checks_to_display and exit_on_error:
+            raise RecipeError(check)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 import versioneer
 
-requirements = ['click >= 6.7', 'future >= 0.12.0', 'jinja2 >= 2.9', 'pyyaml >= 3.12']
+requirements = ['click >= 6.7', 'future >= 0.12.0', 'jinja2 >= 2.9', 'pyyaml >= 3.12', 'six']
 if sys.version_info.major == 2:
     requirements.append('backports.functools_lru_cache >= 1.4')
 
@@ -15,8 +15,8 @@ setup(
     name="conda-verify",
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
-    author="Continuum Analytics, Inc.",
-    author_email="conda@continuum.io",
+    author="Anaconda, Inc.",
+    author_email="conda@anaconda.com",
     url="https://github.com/conda/conda-verify",
     license="BSD",
     description="A tool for validating conda recipes and conda packages",

--- a/tests/functional_tests/test_invalid_packages.py
+++ b/tests/functional_tests/test_invalid_packages.py
@@ -21,7 +21,7 @@ def test_invalid_package_sequence(package_dir, verifier):
     package = os.path.join(package_dir, 'test_-file.tar.bz2')
 
     with pytest.raises(PackageError) as excinfo:
-        verifier.verify_package(path_to_package=package)
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     assert ('PackageError: '
             'Found invalid sequence "_-" '
@@ -32,7 +32,7 @@ def test_invalid_package_extension(package_dir, verifier):
     package = os.path.join(package_dir, 'testfile.zip')
 
     with pytest.raises(PackageError) as excinfo:
-        verifier.verify_package(path_to_package=package)
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     assert ("PackageError: "
             'Found package with invalid extension ".zip"' in str(excinfo))
@@ -41,8 +41,8 @@ def test_invalid_package_extension(package_dir, verifier):
 def test_duplicate_members(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.1-py36_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -52,8 +52,8 @@ def test_duplicate_members(package_dir, verifier, capfd):
 def test_index_unicode(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.2-py36_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -63,8 +63,8 @@ def test_index_unicode(package_dir, verifier, capfd):
 def test_info_in_files_file(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.3-py36_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -74,8 +74,8 @@ def test_info_in_files_file(package_dir, verifier, capfd):
 def test_duplicates_in_files_file(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.4-py36_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -85,8 +85,8 @@ def test_duplicates_in_files_file(package_dir, verifier, capfd):
 def test_not_in_files_file(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.5-py36_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -96,8 +96,8 @@ def test_not_in_files_file(package_dir, verifier, capfd):
 def test_not_in_tarball(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.6-py36_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -107,8 +107,8 @@ def test_not_in_tarball(package_dir, verifier, capfd):
 def test_not_allowed_files(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.7-py36_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -118,8 +118,8 @@ def test_not_allowed_files(package_dir, verifier, capfd):
 def test_file_not_allowed(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.8-py36_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -129,8 +129,8 @@ def test_file_not_allowed(package_dir, verifier, capfd):
 def test_invalid_package_name(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.9-py36_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -140,8 +140,8 @@ def test_invalid_package_name(package_dir, verifier, capfd):
 def test_invalid_build_number(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.10-py36_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -151,8 +151,8 @@ def test_invalid_build_number(package_dir, verifier, capfd):
 def test_duplicates_in_bin(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.11-py36_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -162,8 +162,8 @@ def test_duplicates_in_bin(package_dir, verifier, capfd):
 def test_win_package_warning(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.12-py36_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -173,8 +173,8 @@ def test_win_package_warning(package_dir, verifier, capfd):
 def test_win_package_binary_warning(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.13-py36_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -184,8 +184,8 @@ def test_win_package_binary_warning(package_dir, verifier, capfd):
 def test_package_placeholder_warning(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.14-py36_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -196,8 +196,8 @@ def test_package_placeholder_warning(package_dir, verifier, capfd):
 def test_invalid_prefix_mode(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.15-py36_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -207,8 +207,8 @@ def test_invalid_prefix_mode(package_dir, verifier, capfd):
 def test_unicode_prefix(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.16-py36_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -218,8 +218,8 @@ def test_unicode_prefix(package_dir, verifier, capfd):
 def test_invalid_script_name(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.17-py36_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -229,8 +229,8 @@ def test_invalid_script_name(package_dir, verifier, capfd):
 def test_invalid_setuptools(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.18-py36_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
     
@@ -241,8 +241,8 @@ def test_invalid_setuptools(package_dir, verifier, capfd):
 def test_invalid_eggfile(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.19-py36_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -252,8 +252,8 @@ def test_invalid_eggfile(package_dir, verifier, capfd):
 def test_invalid_namespace_file(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.21-py36_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -263,8 +263,8 @@ def test_invalid_namespace_file(package_dir, verifier, capfd):
 def test_invalid_pyo_file(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.22-py36_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -274,8 +274,8 @@ def test_invalid_pyo_file(package_dir, verifier, capfd):
 def test_invalid_pyc_and_so_files(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.23-py36_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -286,8 +286,8 @@ def test_invalid_pyc_and_so_files(package_dir, verifier, capfd):
 def test_invalid_pickle_file(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.24-py36_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -297,8 +297,8 @@ def test_invalid_pickle_file(package_dir, verifier, capfd):
 def test_missing_pyc_file(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.25-py27_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -308,8 +308,8 @@ def test_missing_pyc_file(package_dir, verifier, capfd):
 def test_invalid_windows_architecture(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.26-py27_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -319,8 +319,8 @@ def test_invalid_windows_architecture(package_dir, verifier, capfd):
 def test_invalid_windows_dll(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.27-py27_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -330,8 +330,8 @@ def test_invalid_windows_dll(package_dir, verifier, capfd):
 def test_invalid_easy_install_file(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.31-py27_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -341,8 +341,8 @@ def test_invalid_easy_install_file(package_dir, verifier, capfd):
 def test_non_ascii_path(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.39-py36_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -352,19 +352,19 @@ def test_non_ascii_path(package_dir, verifier, capfd):
 def test_ascii_in_files_file(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.40-py36_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
-    assert 'C1119 Found filenames in info/files containing non-ascii characters' in error
+    assert 'C1119' in error
 
 
 def test_missing_depends_key(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.41-py36_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -374,8 +374,8 @@ def test_missing_depends_key(package_dir, verifier, capfd):
 def test_invalid_license_family(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.42-py36_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -385,8 +385,8 @@ def test_invalid_license_family(package_dir, verifier, capfd):
 def test_invalid_file_hash(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.43-py36_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -396,8 +396,8 @@ def test_invalid_file_hash(package_dir, verifier, capfd):
 def test_invalid_file_size(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.44-py36_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -407,8 +407,8 @@ def test_invalid_file_size(package_dir, verifier, capfd):
 def test_duplicate_menu_json(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.45-py36_0.tar')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -418,8 +418,8 @@ def test_duplicate_menu_json(package_dir, verifier, capfd):
 def test_invalid_menu_json(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.46-py36_0.tar')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -429,8 +429,8 @@ def test_invalid_menu_json(package_dir, verifier, capfd):
 def test_python_binary_warning(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'python-0.0.1-py36_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -440,8 +440,8 @@ def test_python_binary_warning(package_dir, verifier, capfd):
 def test_invalid_package_placeholder(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.47-py27_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -451,8 +451,8 @@ def test_invalid_package_placeholder(package_dir, verifier, capfd):
 def test_invalid_dependency_specs(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.48-py27_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -462,8 +462,8 @@ def test_invalid_dependency_specs(package_dir, verifier, capfd):
 def test_empty_dependencies(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.49-py27_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -473,8 +473,8 @@ def test_empty_dependencies(package_dir, verifier, capfd):
 def test_invalid_build_string(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.50-py36_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -484,8 +484,8 @@ def test_invalid_build_string(package_dir, verifier, capfd):
 def test_invalid_build_number_negative(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.51-py36_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -495,8 +495,8 @@ def test_invalid_build_number_negative(package_dir, verifier, capfd):
 def test_invalid_version_suffix(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.52-py36_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -506,8 +506,8 @@ def test_invalid_version_suffix(package_dir, verifier, capfd):
 def test_invalid_version(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.53-py36_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -517,8 +517,8 @@ def test_invalid_version(package_dir, verifier, capfd):
 def test_missing_version(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.54-py36_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -528,8 +528,8 @@ def test_missing_version(package_dir, verifier, capfd):
 def test_invalid_package_name_pattern(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.55-py36_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -539,8 +539,8 @@ def test_invalid_package_name_pattern(package_dir, verifier, capfd):
 def test_missing_package_name(package_dir, verifier, capfd):
     package = os.path.join(package_dir, 'testfile-0.0.56-py36_0.tar.bz2')
 
-    with pytest.raises(SystemExit):
-        verifier.verify_package(path_to_package=package)
+    with pytest.raises(PackageError):
+        verifier.verify_package(path_to_package=package, exit_on_error=True)
 
     output, error = capfd.readouterr()
 

--- a/tests/functional_tests/test_invalid_recipes.py
+++ b/tests/functional_tests/test_invalid_recipes.py
@@ -4,6 +4,7 @@ import pytest
 
 from conda_verify import utilities
 from conda_verify.verify import Verify
+from conda_verify.errors import RecipeError
 
 
 @pytest.fixture
@@ -21,8 +22,8 @@ def test_invalid_package_field(recipe_dir, verifier, capfd):
     recipe = os.path.join(recipe_dir, 'invalid_package_field')
     metadata = utilities.render_metadata(recipe, None)
 
-    with pytest.raises(SystemExit):
-        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe)
+    with pytest.raises(RecipeError):
+        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -33,8 +34,8 @@ def test_invalid_package_field_key(recipe_dir, verifier, capfd):
     recipe = os.path.join(recipe_dir, 'invalid_package_field_key')
     metadata = utilities.render_metadata(recipe, None)
 
-    with pytest.raises(SystemExit):
-        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe)
+    with pytest.raises(RecipeError):
+        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -45,8 +46,8 @@ def test_invalid_source_field_key(recipe_dir, verifier, capfd):
     recipe = os.path.join(recipe_dir, 'invalid_source_field_key')
     metadata = utilities.render_metadata(recipe, None)
 
-    with pytest.raises(SystemExit):
-        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe)
+    with pytest.raises(RecipeError):
+        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -57,8 +58,8 @@ def test_invalid_multiple_source_field_key(recipe_dir, verifier, capfd):
     recipe = os.path.join(recipe_dir, 'invalid_multiple_sources')
     metadata = utilities.render_metadata(recipe, None)
 
-    with pytest.raises(SystemExit):
-        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe)
+    with pytest.raises(RecipeError):
+        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -69,8 +70,8 @@ def test_invalid_build_field_key(recipe_dir, verifier, capfd):
     recipe = os.path.join(recipe_dir, 'invalid_build_field_key')
     metadata = utilities.render_metadata(recipe, None)
 
-    with pytest.raises(SystemExit):
-        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe)
+    with pytest.raises(RecipeError):
+        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -81,8 +82,8 @@ def test_invalid_requirements_field_key(recipe_dir, verifier, capfd):
     recipe = os.path.join(recipe_dir, 'invalid_requirements_field_key')
     metadata = utilities.render_metadata(recipe, None)
 
-    with pytest.raises(SystemExit):
-        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe)
+    with pytest.raises(RecipeError):
+        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -93,8 +94,8 @@ def test_invalid_test_field_key(recipe_dir, verifier, capfd):
     recipe = os.path.join(recipe_dir, 'invalid_test_field_key')
     metadata = utilities.render_metadata(recipe, None)
 
-    with pytest.raises(SystemExit):
-        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe)
+    with pytest.raises(RecipeError):
+        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -105,9 +106,9 @@ def test_invalid_about_field_key(recipe_dir, verifier, capfd):
     recipe = os.path.join(recipe_dir, 'invalid_about_field_key')
     metadata = utilities.render_metadata(recipe, None)
 
-    with pytest.raises(SystemExit):
+    with pytest.raises(RecipeError):
         verifier.verify_recipe(rendered_meta=metadata,
-                               recipe_dir=recipe)
+                               recipe_dir=recipe, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -118,8 +119,8 @@ def test_invalid_app_field_key(recipe_dir, verifier, capfd):
     recipe = os.path.join(recipe_dir, 'invalid_app_field_key')
     metadata = utilities.render_metadata(recipe, None)
 
-    with pytest.raises(SystemExit):
-        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe)
+    with pytest.raises(RecipeError):
+        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -130,8 +131,8 @@ def test_invalid_package_name(recipe_dir, verifier, capfd):
     recipe = os.path.join(recipe_dir, 'invalid_package_name')
     metadata = utilities.render_metadata(recipe, None)
 
-    with pytest.raises(SystemExit):
-        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe)
+    with pytest.raises(RecipeError):
+        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -142,8 +143,8 @@ def test_invalid_package_sequence(recipe_dir, verifier, capfd):
     recipe = os.path.join(recipe_dir, 'invalid_package_sequence')
     metadata = utilities.render_metadata(recipe, None)
 
-    with pytest.raises(SystemExit):
-        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe)
+    with pytest.raises(RecipeError):
+        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -154,8 +155,8 @@ def test_no_package_version(recipe_dir, verifier, capfd):
     recipe = os.path.join(recipe_dir, 'no_package_version')
     metadata = utilities.render_metadata(recipe, None)
 
-    with pytest.raises(SystemExit):
-        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe)
+    with pytest.raises(RecipeError):
+        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -166,8 +167,8 @@ def test_invalid_package_version(recipe_dir, verifier, capfd):
     recipe = os.path.join(recipe_dir, 'invalid_package_version')
     metadata = utilities.render_metadata(recipe, None)
 
-    with pytest.raises(SystemExit):
-        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe)
+    with pytest.raises(RecipeError):
+        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -178,8 +179,8 @@ def test_invalid_package_version_prefix(recipe_dir, verifier, capfd):
     recipe = os.path.join(recipe_dir, 'invalid_package_version_prefix')
     metadata = utilities.render_metadata(recipe, None)
 
-    with pytest.raises(SystemExit):
-        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe)
+    with pytest.raises(RecipeError):
+        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -190,8 +191,8 @@ def test_invalid_package_version_sequence(recipe_dir, verifier, capfd):
     recipe = os.path.join(recipe_dir, 'invalid_package_version_sequence')
     metadata = utilities.render_metadata(recipe, None)
 
-    with pytest.raises(SystemExit):
-        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe)
+    with pytest.raises(RecipeError):
+        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -202,8 +203,8 @@ def test_invalid_build_number(recipe_dir, verifier, capfd):
     recipe = os.path.join(recipe_dir, 'invalid_build_number')
     metadata = utilities.render_metadata(recipe, None)
 
-    with pytest.raises(SystemExit):
-        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe)
+    with pytest.raises(RecipeError):
+        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -214,8 +215,8 @@ def test_invalid_build_number_negative(recipe_dir, verifier, capfd):
     recipe = os.path.join(recipe_dir, 'invalid_build_number_negative')
     metadata = utilities.render_metadata(recipe, None)
 
-    with pytest.raises(SystemExit):
-        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe)
+    with pytest.raises(RecipeError):
+        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -226,8 +227,8 @@ def test_invalid_source_url(recipe_dir, verifier, capfd):
     recipe = os.path.join(recipe_dir, 'invalid_source_url')
     metadata = utilities.render_metadata(recipe, None)
 
-    with pytest.raises(SystemExit):
-        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe)
+    with pytest.raises(RecipeError):
+        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -238,8 +239,8 @@ def test_invalid_about_summary(recipe_dir, verifier, capfd):
     recipe = os.path.join(recipe_dir, 'invalid_about_summary')
     metadata = utilities.render_metadata(recipe, None)
 
-    with pytest.raises(SystemExit):
-        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe)
+    with pytest.raises(RecipeError):
+        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -250,8 +251,8 @@ def test_invalid_about_url(recipe_dir, verifier, capfd):
     recipe = os.path.join(recipe_dir, 'invalid_about_url')
     metadata = utilities.render_metadata(recipe, None)
 
-    with pytest.raises(SystemExit):
-        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe)
+    with pytest.raises(RecipeError):
+        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -262,8 +263,8 @@ def test_invalid_source_hash(recipe_dir, verifier, capfd):
     recipe = os.path.join(recipe_dir, 'invalid_source_hash')
     metadata = utilities.render_metadata(recipe, None)
 
-    with pytest.raises(SystemExit):
-        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe)
+    with pytest.raises(RecipeError):
+        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -274,8 +275,8 @@ def test_invalid_license_family(recipe_dir, verifier, capfd):
     recipe = os.path.join(recipe_dir, 'invalid_license_family')
     metadata = utilities.render_metadata(recipe, None)
 
-    with pytest.raises(SystemExit):
-        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe)
+    with pytest.raises(RecipeError):
+        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -286,8 +287,8 @@ def test_invalid_test_files(recipe_dir, verifier, capfd):
     recipe = os.path.join(recipe_dir, 'invalid_test_files')
     metadata = utilities.render_metadata(recipe, None)
 
-    with pytest.raises(SystemExit):
-        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe)
+    with pytest.raises(RecipeError):
+        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -298,8 +299,8 @@ def test_invalid_test_file_path(recipe_dir, verifier, capfd):
     recipe = os.path.join(recipe_dir, 'invalid_test_file_path')
     metadata = utilities.render_metadata(recipe, None)
 
-    with pytest.raises(SystemExit):
-        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe)
+    with pytest.raises(RecipeError):
+        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -310,8 +311,8 @@ def test_invalid_dir_content(recipe_dir, verifier, capfd):
     recipe = os.path.join(recipe_dir, 'invalid_dir_content')
     metadata = utilities.render_metadata(recipe, None)
 
-    with pytest.raises(SystemExit):
-        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe)
+    with pytest.raises(RecipeError):
+        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -323,8 +324,8 @@ def test_invalid_dir_content_filesize(recipe_dir, verifier, capfd):
     recipe = os.path.join(recipe_dir, 'invalid_dir_content_filesize')
     metadata = utilities.render_metadata(recipe, None)
 
-    with pytest.raises(SystemExit):
-        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe)
+    with pytest.raises(RecipeError):
+        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -336,8 +337,8 @@ def test_duplicate_version_specifications(recipe_dir, verifier, capfd):
     recipe = os.path.join(recipe_dir, 'duplicate_version_specs')
     metadata = utilities.render_metadata(recipe, None)
 
-    with pytest.raises(SystemExit):
-        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe)
+    with pytest.raises(RecipeError):
+        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -348,8 +349,8 @@ def test_conda_forge_example_recipe(recipe_dir, verifier, capfd):
     recipe = os.path.join(recipe_dir, 'conda_forge')
     metadata = utilities.render_metadata(recipe, None)
 
-    with pytest.raises(SystemExit):
-        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe)
+    with pytest.raises(RecipeError):
+        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -360,8 +361,8 @@ def test_invalid_outputs(recipe_dir, verifier, capfd):
     recipe = os.path.join(recipe_dir, 'invalid_output')
     metadata = utilities.render_metadata(recipe, None)
 
-    with pytest.raises(SystemExit):
-        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe)
+    with pytest.raises(RecipeError):
+        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -374,8 +375,8 @@ def test_invalid_sources(recipe_dir, verifier, capfd):
     recipe = os.path.join(recipe_dir, 'invalid_sources')
     metadata = utilities.render_metadata(recipe, None)
 
-    with pytest.raises(SystemExit):
-        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe)
+    with pytest.raises(RecipeError):
+        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -386,8 +387,8 @@ def test_duplicate_build_requirements(recipe_dir, verifier, capfd):
     recipe = os.path.join(recipe_dir, 'duplicate_build_requirements')
     metadata = utilities.render_metadata(recipe, None)
 
-    with pytest.raises(SystemExit):
-        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe)
+    with pytest.raises(RecipeError):
+        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -401,8 +402,8 @@ def test_invalid_build_requirement_name(recipe_dir, verifier, capfd):
     recipe = os.path.join(recipe_dir, 'invalid_build_requirement_name')
     metadata = utilities.render_metadata(recipe, None)
 
-    with pytest.raises(SystemExit):
-        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe)
+    with pytest.raises(RecipeError):
+        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -415,8 +416,8 @@ def test_invalid_build_requirement_version(recipe_dir, verifier, capfd):
     recipe = os.path.join(recipe_dir, 'invalid_build_requirement_version')
     metadata = utilities.render_metadata(recipe, None)
 
-    with pytest.raises(SystemExit):
-        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe)
+    with pytest.raises(RecipeError):
+        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -429,8 +430,8 @@ def test_invalid_run_requirement_name(recipe_dir, verifier, capfd):
     recipe = os.path.join(recipe_dir, 'invalid_run_requirement_name')
     metadata = utilities.render_metadata(recipe, None)
 
-    with pytest.raises(SystemExit):
-        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe)
+    with pytest.raises(RecipeError):
+        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe, exit_on_error=True)
 
     output, error = capfd.readouterr()
 
@@ -443,8 +444,8 @@ def test_no_package_name(recipe_dir, verifier, capfd):
     recipe = os.path.join(recipe_dir, 'no_package_name')
     metadata = utilities.render_metadata(recipe, None)
 
-    with pytest.raises(SystemExit):
-        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe)
+    with pytest.raises(RecipeError):
+        verifier.verify_recipe(rendered_meta=metadata, recipe_dir=recipe, exit_on_error=True)
 
     output, error = capfd.readouterr()
 


### PR DESCRIPTION
This changes the verify logic so that errors are always printed, but an exception is only raised if the exit option is set.  This will help ease the transition into using conda-verify again.

Default behavior is to not exit - only warn.