### PR TITLE
Reconcile conda-verify license families to conda-build license families

### DIFF
--- a/conda_verify/constants.py
+++ b/conda_verify/constants.py
@@ -3,8 +3,8 @@ try:
 except ImportError:
     print("warning: could not import conda-build ALLOWED_LICENSE_FAMILIES data.  Falling back to "
           "possibly stale static list")
-    LICENSE_FAMILIES = ['AGPL', 'GPL', 'GPL2', 'GPL3', 'LGPL', 'BSD', 'MIT', 'Apache',
-                        'PSF', 'Public-Domain', 'Proprietary', 'Other']
+    LICENSE_FAMILIES = ['AGPL', 'GPL', 'GPL2', 'GPL3', 'LGPL', 'BSD', 'MIT', 'APACHE',
+                        'PSF', 'CC', 'PUBLIC-DOMAIN', 'PROPRIETARY', 'OTHER', 'NONE']
 
 try:
     from conda_build.metadata import FIELDS


### PR DESCRIPTION
fixes #48 

I upper-cased the licenses in the license families so that they are the same as the ones in the conda-build license families. If we should instead do a case-insensitive check let me know and I'll push a commit for that.

cc @msarahan 

