### PR TITLE
I think, under legacy noarch python it is valid to not have a paths_json

### DIFF
--- a/conda_verify/checks.py
+++ b/conda_verify/checks.py
@@ -79,8 +79,12 @@ class CondaPackageCheck(object):
         except IOError:
             self.prefix_file = None
 
-        with open(os.path.join(self.tmpdir, "info", "paths.json")) as f:
-            self.paths_json = json.load(f)
+        try:
+        with open(os.path.join(self.tmpdir, 'info', 'paths.json')) as f:
+                self.paths_json = json.load(f)
+        except IOError:
+            assert self.info.subdir == 'noarch'
+            self.paths_json = {}
 
         self.win_pkg = bool(self.info["platform"] == "win")
         self.name_pat = re.compile(r"[a-z0-9_][a-z0-9_\-\.]*$")


### PR DESCRIPTION
<!---
Thanks for opening a PR on conda-verify!
 Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html
 If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
 Thanks again!
-->
