### PR TITLE
remove assertion of subdir == noarch when looking for paths.json

### DIFF
--- a/conda_verify/checks.py
+++ b/conda_verify/checks.py
@@ -86,7 +86,6 @@ class CondaPackageCheck(object):
                 for path in self.paths_json['paths']:
                     self.paths_json_path[path["_path"]] = path
         except IOError:
-            assert self.info.subdir == 'noarch'
             self.paths_json = {}
 
         self.win_pkg = bool(self.info["platform"] == "win")


### PR DESCRIPTION
This fixes a failing test in conda-build
