### PR TITLE
Windows: ensure binaries do not link to Visual Studio debug libraries

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,6 @@
+  * add C1149: detect when Windows binaries are linked against Visual Studio debug DLLs  #75
+
+
 2018-09-28   3.1.1:
 -------------------
   * Fix bat/exe check to only fail when .bat and .exe files with same name exist  #49

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Checks
     C1146 - Found file "{}" with sha256 hash different than listed in paths.json
     C1147 - Found file "{}" with filesize different than listed in paths.json
     C1148 - Found architecture specific file "{}" in package
+    C1149 - Found binary "{}" linking to VS debug library: "{}"
     C2101 - Missing package name in meta.yaml
     C2102 - Found invalid package name "{}" in meta.yaml
     C2103 - Found invalid sequence "{}" in package name

--- a/conda_verify/checks.py
+++ b/conda_verify/checks.py
@@ -636,6 +636,7 @@ class CondaPackageCheck(object):
             return
         if not any(member.endswith((".exe", ".dll")) for member in self.archive_members):
             return
+        # only import lief when necessary
         import lief.PE
 
         pat = re.compile(r"vcruntime\d+d\.dll", re.IGNORECASE)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - conda-package-handling >=1.0.4
     - six
     - tqdm
+    - py-lief
 
 test:
   imports:


### PR DESCRIPTION
We use `lief` to find out which DLLs Windows binaries are linked against.
When we detect a Visual Studio debug DLL, we raise the new check error C1149.
The problem with VS debug DLL is that these cannot be shipped to end users,
but are present on Windows build machines, such that linkage to those DLLs go
undetected by tests (executing a `.exe` or importing module).
