### PR TITLE
Rename master to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # conda-verify
-[![Travis branch](https://img.shields.io/travis/conda/conda-verify/master.svg?style=flat-square)](https://travis-ci.org/conda/conda-verify)
-[![Codecov branch](https://img.shields.io/codecov/c/github/conda/conda-verify/master.svg?style=flat-square)](https://codecov.io/gh/conda/conda-verify)
+[![Travis branch](https://img.shields.io/travis/conda/conda-verify/main.svg?style=flat-square)](https://travis-ci.org/conda/conda-verify)
+[![Codecov branch](https://img.shields.io/codecov/c/github/conda/conda-verify/main.svg?style=flat-square)](https://codecov.io/gh/conda/conda-verify)
 
 conda-verify is a tool for (passively) verifying conda recipes and
 conda packages. The purpose of this verification process is to ensure that


### PR DESCRIPTION
The minor modifications needed for renaming the default branch from master to main.

Xref: https://github.com/conda/conda/issues/11517