### PR TITLE
Version specs using the "!=" operator no longer flagged as invalid

### DIFF
--- a/conda_verify/checks.py
+++ b/conda_verify/checks.py
@@ -33,7 +33,7 @@ from conda_verify.utilities import (
 )
 
 
-ver_spec_pat = r"^(?:[><=]{0,2}(?:(?:[\d\*]+[!\._]?){1,})[+\w\*]*[|,]?){1,}"
+ver_spec_pat = r"^(?:[=><!]?=?(?:(?:[\d\*]+[!\._]?){1,})[+\w\*]*[|,]?){1,}"
 
 
 def _checksum(fd, algorithm, buffersize=65536):

--- a/news/notequals
+++ b/news/notequals
@@ -1,0 +1,3 @@
+### Bug fixes
+
+* Version specs using the "!=" operator no longer flagged as invalid

--- a/tests/unit_tests/test_regex.py
+++ b/tests/unit_tests/test_regex.py
@@ -26,6 +26,7 @@ def test_ver_spec_pat(package_dir, recipe_dir):
     pin_version_long = '<=2.0.0*,<3.0.0*'
     prerelease_version = '2.0rc1'
     pin_prerelease_version = '>=1.9.3,<2.0.0a0'
+    notequals_version = '>=0.7,!=1.1.0,<2.2'
     or_version = '1.0|1.2.*'
     regex_version = '3.6*'
     python_version = '3.6.*'
@@ -37,6 +38,7 @@ def test_ver_spec_pat(package_dir, recipe_dir):
     assert utilities.fullmatch(package_ver_spec_pat, pin_version_long)
     assert utilities.fullmatch(package_ver_spec_pat, prerelease_version)
     assert utilities.fullmatch(package_ver_spec_pat, pin_prerelease_version)
+    assert utilities.fullmatch(package_ver_spec_pat, notequals_version)
     assert utilities.fullmatch(package_ver_spec_pat, or_version)
     assert utilities.fullmatch(package_ver_spec_pat, regex_version)
     assert utilities.fullmatch(package_ver_spec_pat, python_version)
@@ -48,6 +50,7 @@ def test_ver_spec_pat(package_dir, recipe_dir):
     assert utilities.fullmatch(recipe_ver_spec_pat, pin_version_long)
     assert utilities.fullmatch(recipe_ver_spec_pat, prerelease_version)
     assert utilities.fullmatch(recipe_ver_spec_pat, pin_prerelease_version)
+    assert utilities.fullmatch(recipe_ver_spec_pat, notequals_version)
     assert utilities.fullmatch(recipe_ver_spec_pat, or_version)
     assert utilities.fullmatch(recipe_ver_spec_pat, regex_version)
     assert utilities.fullmatch(recipe_ver_spec_pat, python_version)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Package match specifications containing the PEP440 "!=" operator are no longer flagged as being invalid by conda-verify.

Fixes #101 

Example of a requirement that previously causes spurious C1114 / C2114 errors, now considered valid:

```
trafaret <2.2,>=0.7,!=1.1.0
```

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [X] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [X] Add / update necessary tests?