### PR TITLE
Replace logger.warn w/ logger.warning

### DIFF
--- a/conda_verify/verify.py
+++ b/conda_verify/verify.py
@@ -22,7 +22,7 @@ class Verify(object):
         if ("ignore_scripts" in kw and kw["ignore_scripts"]) or (
             "run_scripts" in kw and kw["run_scripts"]
         ):
-            getLogger(__name__).warn(
+            getLogger(__name__).warning(
                 "Ignoring legacy ignore_scripts or run_scripts.  These have "
                 "been replaced by the checks_to_ignore argument, which takes a"
                 "list of codes, documented at https://github.com/conda/conda-verify#checks"
@@ -64,7 +64,7 @@ class Verify(object):
         if ("ignore_scripts" in kw and kw["ignore_scripts"]) or (
             "run_scripts" in kw and kw["run_scripts"]
         ):
-            getLogger(__name__).warn(
+            getLogger(__name__).warning(
                 "Ignoring legacy ignore_scripts or run_scripts.  These have "
                 "been replaced by the checks_to_ignore argument, which takes a"
                 "list of codes, documented at https://github.com/conda/conda-verify#checks"


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

This replaces calls to `logger.warn` with `logger.warning`. The former has been deprecated since Python 3.3 and generates `DeprecationWarning`s that can make output particularly in debugging and testing more noisy than necessary.

Also see conda/conda#13963.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
